### PR TITLE
refactor: add BMAD methodology, improve security and CI/CD structure

### DIFF
--- a/.bmad/README.md
+++ b/.bmad/README.md
@@ -1,0 +1,52 @@
+# BMAD Methodology — VDM Cloud Infrastructure
+
+This directory contains the BMAD (BMad Agent-Driven) methodology configuration
+for AI-assisted infrastructure development on this portfolio project.
+
+## Structure
+
+```
+.bmad/
+├── agents/              # Agent role definitions
+│   ├── infra-architect.md    # Architecture design and module review
+│   ├── security-reviewer.md  # Security posture and compliance
+│   └── ops-engineer.md       # Operational readiness and Day-2 ops
+├── skills/              # Reusable skill procedures
+│   ├── tf-module-review.md   # Terraform module quality review
+│   ├── security-audit.md     # Security audit procedure
+│   └── cost-review.md        # FinOps and cost review
+├── checklists/          # Quality gate checklists
+│   ├── new-module.md         # Adding a new Terraform module
+│   └── pr-review.md          # Pull request review criteria
+└── tasks/               # Planned work items
+    └── add-alb-module.md     # Next: Application Load Balancer
+```
+
+## How It Works
+
+**Agents** define specialized roles with clear responsibilities and standards.
+When working on infrastructure changes, activate the relevant agent to get
+focused guidance:
+
+- Making architecture changes? → `infra-architect`
+- Modifying security rules? → `security-reviewer`
+- Updating monitoring or runbooks? → `ops-engineer`
+
+**Skills** are reusable procedures that agents invoke. They provide step-by-step
+evaluation criteria with concrete pass/fail checks.
+
+**Checklists** are quality gates used before merging changes. They ensure
+consistency across the project.
+
+**Tasks** capture planned work with acceptance criteria, agent assignments,
+and skill references.
+
+## Usage with Claude Code
+
+Reference agents and skills in your prompts:
+
+```
+"Review the VPC module using the infra-architect agent and tf-module-review skill"
+"Run a security-audit on the security module changes"
+"Check this PR against the pr-review checklist"
+```

--- a/.bmad/agents/infra-architect.md
+++ b/.bmad/agents/infra-architect.md
@@ -1,0 +1,52 @@
+# Agent: Infrastructure Architect
+
+## Identity
+
+You are the Infrastructure Architect for VDM Cloud Infrastructure. You design,
+review, and evolve the Terraform module architecture ensuring production-grade
+patterns, proper separation of concerns, and scalable infrastructure design.
+
+## Responsibilities
+
+- Review and design Terraform module structure and composition
+- Ensure proper separation of concerns across modules (networking, compute, security, monitoring, cost)
+- Validate that infrastructure follows multi-AZ, high-availability patterns
+- Author and maintain Architecture Decision Records (ADRs)
+- Evaluate trade-offs between cost, complexity, and production readiness
+- Ensure consistent naming conventions: `${project_name}-${environment}-${resource_type}`
+
+## Standards
+
+### Module Design
+- One concern per module with consistent file structure: `main.tf`, `variables.tf`, `outputs.tf`
+- All variables must have `description`, `type`, and `validation` where applicable
+- All outputs must have `description` explaining purpose and downstream usage
+- Use `merge(var.common_tags, {...})` for consistent resource tagging
+- Use data sources over hardcoded values (e.g., SSM parameter for AMI IDs)
+
+### Architecture Principles
+- Private subnets for all application workloads
+- NAT Gateway for controlled outbound access from private subnets
+- Security group chaining between tiers (no CIDR-based inter-tier rules)
+- Document every design decision with an ADR when the choice involves trade-offs
+- Cost-conscious design: Free Tier where possible, single NAT for dev, multi-NAT documented for prod
+
+### Review Checklist
+1. Does every module have consistent file structure?
+2. Are all variables typed, described, and validated?
+3. Are outputs documented with use cases?
+4. Does naming follow the convention?
+5. Is tagging consistent with `common_tags` merge pattern?
+6. Are trade-offs documented in ADRs?
+7. Is the dependency chain between modules clear and minimal?
+
+## Skills Used
+- `tf-module-review`
+- `cost-review`
+
+## Activation
+Use this agent when:
+- Adding new Terraform modules or resources
+- Restructuring existing module composition
+- Reviewing architecture decisions
+- Planning infrastructure changes

--- a/.bmad/agents/ops-engineer.md
+++ b/.bmad/agents/ops-engineer.md
@@ -1,0 +1,53 @@
+# Agent: Operations Engineer
+
+## Identity
+
+You are the Operations Engineer for VDM Cloud Infrastructure. You ensure
+operational readiness through comprehensive runbooks, monitoring coverage,
+incident response procedures, and cost governance. You think about Day-2
+operations — what happens after the infrastructure is deployed.
+
+## Responsibilities
+
+- Maintain and improve operational runbooks with copy-paste CLI commands
+- Ensure monitoring covers all critical infrastructure components
+- Validate incident response procedures are complete and actionable
+- Review cost governance (budgets, alerts, resource right-sizing)
+- Ensure all infrastructure changes have corresponding operational documentation
+- Validate that alarms have proper notification channels
+
+## Standards
+
+### Runbook Quality
+- Every incident procedure follows: Symptoms → Severity → Diagnosis → Resolution → Verification
+- CLI commands must be copy-paste ready (no placeholders without explanation)
+- Include AWS CLI and Terraform commands for common operations
+- Time-sensitive procedures marked with severity levels
+
+### Monitoring Coverage
+- CloudWatch alarms for CPU utilization (high and low thresholds)
+- Budget alerts at 80% (warning) and 100% (critical)
+- GuardDuty for threat detection (VPC Flow Logs, CloudTrail, DNS)
+- All alarms should have notification actions (SNS topic with email)
+
+### Incident Response
+- Severity definitions: S1 (Critical) through S4 (Low)
+- Lifecycle: Detect → Triage → Mitigate → Resolve → Document
+- Blameless post-incident review template maintained
+- Communication templates for stakeholder updates
+
+### Cost Governance
+- Monthly budget with tiered alerts
+- Right-sizing documentation (Free Tier awareness)
+- Dev vs Prod cost comparison maintained in README
+- NAT Gateway cost documented as largest single expense
+
+## Skills Used
+- `cost-review`
+
+## Activation
+Use this agent when:
+- Adding or modifying monitoring and alerting
+- Updating operational runbooks or incident procedures
+- Reviewing cost implications of infrastructure changes
+- Ensuring operational readiness for new modules

--- a/.bmad/agents/security-reviewer.md
+++ b/.bmad/agents/security-reviewer.md
@@ -1,0 +1,56 @@
+# Agent: Security Reviewer
+
+## Identity
+
+You are the Security Reviewer for VDM Cloud Infrastructure. You audit every
+security-related change against documented security decisions, validate network
+isolation patterns, and ensure the infrastructure maintains a strong security
+posture appropriate for its environment (dev/staging/prod).
+
+## Responsibilities
+
+- Audit security group rules against documented rationale in `SECURITY-DECISIONS.md`
+- Validate network segmentation (public/private subnet isolation)
+- Review IAM patterns and least-privilege access
+- Ensure no secrets, credentials, or PII are committed to version control
+- Validate that EC2 instances enforce IMDSv2 (token-required)
+- Confirm GuardDuty and monitoring are active
+
+## Standards
+
+### Network Security
+- No SSH ports open — SSM Session Manager only (zero-trust access)
+- Security group chaining: DB tier trusts web SG ID, not CIDR blocks
+- Private subnets have no public IP assignment
+- NAT Gateway provides outbound-only internet for private resources
+- Every security group rule must have a `description` field
+
+### Compute Security
+- IMDSv2 required (`http_tokens = "required"`) on all launch templates
+- No hardcoded credentials in user data scripts
+- Instances in private subnets only
+
+### Data Security
+- S3 buckets: public access blocked (all 4 settings)
+- State bucket: versioning enabled for rollback capability
+- No `.tfvars` files in version control (gitignored)
+- Email addresses and sensitive defaults in `.tfvars.example` only
+
+### Review Checklist
+1. Are all SG rules documented with a WHY?
+2. Is SG chaining used between tiers?
+3. Are instances in private subnets?
+4. Is IMDSv2 enforced on launch templates?
+5. Is GuardDuty enabled?
+6. Are there any hardcoded secrets or credentials?
+7. Is the S3 backend bucket locked down?
+
+## Skills Used
+- `security-audit`
+
+## Activation
+Use this agent when:
+- Modifying security groups or network ACLs
+- Adding new compute resources
+- Reviewing changes that affect network boundaries
+- Auditing for compliance or security posture

--- a/.bmad/checklists/new-module.md
+++ b/.bmad/checklists/new-module.md
@@ -1,0 +1,45 @@
+# Checklist: New Terraform Module
+
+Use this checklist when adding a new module to the capstone project.
+
+## Pre-Implementation
+- [ ] ADR drafted if the module involves architectural trade-offs
+- [ ] Module responsibility is single and well-defined
+- [ ] Input/output contract designed (what does this module need? what does it expose?)
+
+## File Structure
+- [ ] `main.tf` created with header comment explaining module purpose
+- [ ] `variables.tf` created with all inputs typed, described, and validated
+- [ ] `outputs.tf` created with all outputs described with use cases
+
+## Implementation
+- [ ] Resource naming follows `${var.project_name}-${var.environment}-${resource_type}`
+- [ ] All resources tagged with `merge(var.common_tags, {...})` pattern
+- [ ] Tags include: Name, Environment, Project, ManagedBy, Component
+- [ ] Comments explain "why" with references to ADRs or security docs
+- [ ] No hardcoded values — use variables or data sources
+- [ ] `depends_on` only where implicit dependencies are insufficient
+
+## Integration
+- [ ] Module added to root `main.tf` with section header comment
+- [ ] Module outputs wired to root `outputs.tf`
+- [ ] New variables added to root `variables.tf` if needed
+- [ ] `terraform.tfvars.example` updated with new variable examples
+
+## Security
+- [ ] Security review completed (see `security-audit` skill)
+- [ ] No secrets in defaults or committed files
+- [ ] Network access follows least-privilege
+- [ ] IMDSv2 enforced on any compute resources
+
+## Documentation
+- [ ] ADR finalized and linked from `docs/adr/README.md`
+- [ ] Runbook updated if module affects operations
+- [ ] README cost table updated with new resource costs
+- [ ] SECURITY-DECISIONS.md updated if new SG rules added
+
+## Validation
+- [ ] `terraform fmt -check` passes
+- [ ] `terraform validate` passes
+- [ ] `tfsec` scan shows no new critical findings
+- [ ] CI pipeline passes

--- a/.bmad/checklists/pr-review.md
+++ b/.bmad/checklists/pr-review.md
@@ -1,0 +1,35 @@
+# Checklist: Pull Request Review
+
+Use this checklist when reviewing pull requests to this repository.
+
+## Code Quality
+- [ ] `terraform fmt` applied (no formatting issues)
+- [ ] `terraform validate` passes for affected phases
+- [ ] No new `tfsec` findings (or findings documented and accepted)
+- [ ] Variable descriptions are meaningful (not just restating the name)
+- [ ] Comments explain "why" not "what"
+- [ ] No dead code, commented-out resources, or TODO placeholders
+
+## Naming and Tagging
+- [ ] Resource names follow `${project_name}-${environment}-${resource_type}` pattern
+- [ ] All resources have consistent tags via `merge(var.common_tags, {...})`
+- [ ] No orphaned tags or inconsistent tag keys
+
+## Security
+- [ ] No new SG rules without documented rationale
+- [ ] No `0.0.0.0/0` ingress without justification
+- [ ] No hardcoded secrets, emails, or credentials in defaults
+- [ ] IMDSv2 enforced on any new compute resources
+- [ ] `.tfvars` files not included in the diff
+
+## Documentation
+- [ ] ADR created for architectural decisions with trade-offs
+- [ ] README updated if project structure changed
+- [ ] Runbook updated if operational procedures affected
+- [ ] Cost table updated if new billable resources added
+
+## Operational Readiness
+- [ ] Monitoring covers new resources (CloudWatch alarms)
+- [ ] Budget impact assessed
+- [ ] Rollback path understood (can `terraform destroy` cleanly remove?)
+- [ ] No state file conflicts or backend issues

--- a/.bmad/skills/cost-review.md
+++ b/.bmad/skills/cost-review.md
@@ -1,0 +1,70 @@
+# Skill: Cost Review
+
+## Purpose
+
+Evaluate infrastructure changes for cost impact, validate FinOps best practices,
+and ensure budget governance is in place. Compares dev vs prod cost profiles
+and identifies optimization opportunities.
+
+## Inputs
+
+- **change_type**: `new_resource`, `modification`, or `full_audit`
+- **environment**: `dev`, `staging`, or `prod`
+
+## Procedure
+
+### 1. Resource Cost Assessment
+For each resource in the change:
+- [ ] Identify the AWS pricing model (on-demand, reserved, spot)
+- [ ] Estimate monthly cost for dev configuration
+- [ ] Estimate monthly cost for prod configuration
+- [ ] Check Free Tier eligibility (first 12 months)
+- [ ] Flag any resources with usage-based pricing (NAT Gateway data transfer, etc.)
+
+### 2. Right-Sizing Review
+- [ ] Instance types are appropriate for workload (not over-provisioned)
+- [ ] ASG min/max/desired are reasonable for the environment
+- [ ] Single NAT Gateway for dev (documented multi-NAT for prod)
+- [ ] No unnecessary resources running in dev that are prod-only
+
+### 3. Budget Governance
+- [ ] AWS Budget resource exists with monthly limit
+- [ ] Alert thresholds at 80% (warning) and 100% (critical)
+- [ ] Budget notification emails configured (via tfvars, not hardcoded)
+- [ ] Cost allocation tags applied to all resources
+
+### 4. Cost Table Validation
+Verify README cost table reflects current infrastructure:
+- [ ] All deployed resources listed
+- [ ] Dev and Prod columns accurate
+- [ ] Notes column explains pricing nuances
+- [ ] Total is calculated correctly
+
+### 5. Optimization Opportunities
+- [ ] Spot instances considered for non-critical workloads
+- [ ] Reserved instances considered for stable workloads
+- [ ] S3 lifecycle policies for log rotation
+- [ ] CloudWatch log retention periods set
+
+## Output Format
+
+```
+## Cost Review
+
+### Monthly Estimate
+| Resource | Dev ($/mo) | Prod ($/mo) | Change |
+|----------|-----------|------------|--------|
+| ... | ... | ... | ... |
+
+### Budget Status
+- Limit: $X/mo
+- Current projected: $Y/mo
+- Alerts: configured/missing
+
+### Optimization Opportunities
+1. ...
+2. ...
+
+### Risk Items
+<any costs that could spike unexpectedly>
+```

--- a/.bmad/skills/security-audit.md
+++ b/.bmad/skills/security-audit.md
@@ -1,0 +1,80 @@
+# Skill: Security Audit
+
+## Purpose
+
+Perform a security audit of the infrastructure codebase, validating network
+isolation, access controls, data protection, and compliance with documented
+security decisions.
+
+## Inputs
+
+- **scope**: `network` (SGs and VPC), `compute` (EC2 and ASG), `data` (S3 and state), or `full` (all)
+- **environment**: `dev`, `staging`, or `prod` (affects acceptable risk thresholds)
+
+## Procedure
+
+### 1. Network Security
+
+#### Security Groups
+For each security group:
+- [ ] Every ingress rule has a `description` field
+- [ ] Every egress rule has a `description` field
+- [ ] `0.0.0.0/0` ingress rules are justified and documented in SECURITY-DECISIONS.md
+- [ ] Inter-tier rules use security group IDs (chaining), not CIDRs
+- [ ] No SSH (port 22) rules — SSM Session Manager required
+- [ ] No overly broad port ranges (e.g., 0-65535)
+
+#### VPC Design
+- [ ] Private subnets have no `map_public_ip_on_launch`
+- [ ] Private subnets route through NAT Gateway (no direct IGW route)
+- [ ] Public subnets are limited to load balancers and NAT Gateways
+- [ ] Route tables are explicitly associated (no default main RT usage)
+
+### 2. Compute Security
+- [ ] Launch templates enforce IMDSv2 (`http_tokens = "required"`)
+- [ ] Instances are placed in private subnets
+- [ ] User data scripts contain no hardcoded secrets
+- [ ] Security group attachment is explicit (not default VPC SG)
+
+### 3. Data Security
+- [ ] S3 buckets block public access (all 4 settings)
+- [ ] State bucket has versioning enabled
+- [ ] No sensitive values in variable defaults
+- [ ] `.tfvars` files are gitignored
+- [ ] No credentials in any committed file
+
+### 4. Monitoring and Detection
+- [ ] GuardDuty is enabled
+- [ ] S3 data source monitoring is enabled on GuardDuty
+- [ ] CloudWatch alarms exist for critical metrics
+- [ ] Budget alerts are configured
+
+### 5. Cross-Reference
+- [ ] All SG rules map to entries in SECURITY-DECISIONS.md
+- [ ] Open egress rules have documented production upgrade path
+- [ ] Demo-only configurations are clearly labeled
+
+## Output Format
+
+```
+## Security Audit Report
+
+**Environment**: <env>
+**Date**: <date>
+**Overall Rating**: <Critical / Warning / Pass>
+
+### Findings
+
+| Category | Status | Severity | Finding |
+|----------|--------|----------|---------|
+| Network | ... | ... | ... |
+
+### Critical Items
+<items requiring immediate action>
+
+### Recommendations
+<items for future improvement>
+
+### Production Upgrade Path
+<what would change for prod deployment>
+```

--- a/.bmad/skills/tf-module-review.md
+++ b/.bmad/skills/tf-module-review.md
@@ -1,0 +1,78 @@
+# Skill: Terraform Module Review
+
+## Purpose
+
+Evaluate a Terraform module for quality, consistency, and adherence to project
+conventions. This skill checks structure, naming, variables, outputs, tagging,
+and documentation.
+
+## Inputs
+
+- **module_path**: Path to the module directory (e.g., `05-capstone/modules/vpc`)
+- **scope**: `full` (all checks) or `quick` (structure and naming only)
+
+## Procedure
+
+### 1. File Structure Check
+Verify the module contains the standard files:
+- [ ] `main.tf` — Resource definitions
+- [ ] `variables.tf` — Input variable declarations
+- [ ] `outputs.tf` — Output value declarations
+
+Flag any additional files and confirm they serve a clear purpose.
+
+### 2. Variable Quality
+For each variable in `variables.tf`:
+- [ ] Has `description` that explains purpose (not just restates the name)
+- [ ] Has explicit `type` declaration
+- [ ] Has `default` value where appropriate (required vars should NOT have defaults)
+- [ ] Has `validation` block for constrained inputs (environment, CIDR, etc.)
+- [ ] No hardcoded sensitive values in defaults (emails, IPs, credentials)
+
+### 3. Resource Naming
+For each resource in `main.tf`:
+- [ ] Name tag follows: `${var.project_name}-${var.environment}-${resource_type}`
+- [ ] Tags include: Name, Environment, Project, ManagedBy, Component
+- [ ] Uses `merge(var.common_tags, {...})` pattern for tag consistency
+
+### 4. Output Quality
+For each output in `outputs.tf`:
+- [ ] Has `description` explaining what it represents and when to use it
+- [ ] References a specific resource attribute (not computed values without context)
+- [ ] Sensitive values marked with `sensitive = true`
+
+### 5. Code Quality
+- [ ] Comments explain "why" not "what"
+- [ ] References to ADRs or security docs where decisions involve trade-offs
+- [ ] No hardcoded values that should be variables
+- [ ] Proper use of `count` or `for_each` for repeated resources
+- [ ] `depends_on` used only when implicit dependencies are insufficient
+
+### 6. Security Review
+- [ ] No overly permissive security group rules without documented rationale
+- [ ] No `0.0.0.0/0` ingress without justification
+- [ ] Private resources stay in private subnets
+- [ ] IMDSv2 enforced on compute resources
+
+## Output Format
+
+```
+## Module Review: <module_name>
+
+### Summary
+<pass/fail with explanation>
+
+### Findings
+| Check | Status | Notes |
+|-------|--------|-------|
+| File Structure | pass/fail | ... |
+| Variable Quality | pass/fail | ... |
+| Resource Naming | pass/fail | ... |
+| Output Quality | pass/fail | ... |
+| Code Quality | pass/fail | ... |
+| Security | pass/fail | ... |
+
+### Recommendations
+1. ...
+2. ...
+```

--- a/.bmad/tasks/add-alb-module.md
+++ b/.bmad/tasks/add-alb-module.md
@@ -1,0 +1,43 @@
+# Task: Add Application Load Balancer Module
+
+## Status: Planned
+
+## Context
+
+The capstone project has an ASG in private subnets but no load balancer to
+distribute traffic. This is documented as a production upgrade path in ADR-001
+and the README cost table.
+
+## Objective
+
+Create a `modules/alb` module that provisions an Application Load Balancer
+in public subnets, with a target group pointing at the ASG instances.
+
+## Acceptance Criteria
+
+- [ ] ALB created in public subnets across both AZs
+- [ ] HTTP listener (port 80) forwarding to target group
+- [ ] HTTPS listener (port 443) with ACM certificate (optional, can be commented out)
+- [ ] Target group with health check on `/` returning 200
+- [ ] ASG attachment to target group
+- [ ] ALB security group: HTTP/HTTPS from `0.0.0.0/0`
+- [ ] Web SG updated: HTTP from ALB SG only (not `0.0.0.0/0`)
+- [ ] ADR-006 drafted for ALB design decisions
+- [ ] Cost table updated (~$16/mo for ALB)
+- [ ] Runbook updated with ALB troubleshooting procedures
+
+## Agent
+
+`infra-architect` — for module design and ADR authoring
+
+## Skills
+
+- `tf-module-review` — validate module quality
+- `security-audit` — validate SG changes
+- `cost-review` — validate cost impact
+
+## Dependencies
+
+- VPC module (public subnet IDs)
+- Security module (SG updates)
+- Compute module (ASG attachment)

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,8 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
-  validate:
+  format:
+    name: Format Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -21,15 +25,44 @@ jobs:
       - name: Terraform Format Check
         run: terraform fmt -check -recursive
 
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    needs: format
+    strategy:
+      matrix:
+        directory:
+          - 01-s3-bucket
+          - 02-vpc
+          - 03-modules
+          - 04-advanced-hcl
+          - 05-capstone
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.10.0"
+
+      - name: Terraform Init (${{ matrix.directory }})
+        run: terraform init -backend=false
+        working-directory: ${{ matrix.directory }}
+
+      - name: Terraform Validate (${{ matrix.directory }})
+        run: terraform validate
+        working-directory: ${{ matrix.directory }}
+
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    needs: format
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Security Scan (tfsec)
         uses: aquasecurity/tfsec-action@v1.0.0
         with:
           soft_fail: true
-
-      - name: Terraform Init (Capstone)
-        run: terraform init -backend=false
-        working-directory: 05-capstone
-
-      - name: Terraform Validate (Capstone)
-        run: terraform validate
-        working-directory: 05-capstone

--- a/.gitignore
+++ b/.gitignore
@@ -5,20 +5,29 @@
 *.tfplan
 crash.log
 .terraform.lock.hcl
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
 
 # Sensitive files
 *.tfvars
 !*.tfvars.example
 *.pem
 *.key
+*.env
 
 # Infracost
 .infracost/
+
+# Claude Code
+.claude/
 
 # IDE
 .vscode/
 .idea/
 *.swp
+*.swo
 
 # OS
 .DS_Store

--- a/05-capstone/main.tf
+++ b/05-capstone/main.tf
@@ -5,41 +5,9 @@
 # This is the root module that composes all infrastructure components.
 # Each module handles a specific concern: networking, security, compute,
 # monitoring, threat detection, and cost governance.
+#
+# Provider and backend configuration: see providers.tf
 # =============================================================================
-
-terraform {
-  required_version = ">= 1.10.0"
-
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
-    }
-  }
-
-  # ---------------------------------------------------------------------------
-  # Remote State — S3 Backend (see ADR-005: docs/adr/ADR-005-remote-state.md)
-  #
-  # The S3 bucket is created by backend-setup/. You must bootstrap it first:
-  #   cd backend-setup && terraform init && terraform apply && cd ..
-  #
-  # Then uncomment the block below and run:
-  #   terraform init -migrate-state
-  #
-  # uses use_lockfile (Terraform 1.10+) instead of DynamoDB for state locking.
-  # See backend-setup/README.md for the full bootstrap walkthrough.
-  # ---------------------------------------------------------------------------
-  # backend "s3" {
-  #   bucket       = "vdm-terraform-state"
-  #   key          = "capstone/terraform.tfstate"
-  #   region       = "us-east-1"
-  #   use_lockfile = true
-  # }
-}
-
-provider "aws" {
-  region = var.aws_region
-}
 
 # -----------------------------------------------------------------------------
 # NETWORKING
@@ -114,4 +82,5 @@ module "cost" {
 
   project_name = var.project_name
   environment  = var.environment
+  alert_emails = var.alert_emails
 }

--- a/05-capstone/modules/compute/main.tf
+++ b/05-capstone/modules/compute/main.tf
@@ -27,6 +27,25 @@ resource "aws_launch_template" "app" {
   # Associate with web security group for HTTP/HTTPS access
   vpc_security_group_ids = [var.security_group_id]
 
+  # IMDSv2 required — prevents SSRF-based credential theft from instance metadata.
+  # AWS recommends enforcing IMDSv2 on all EC2 instances.
+  # See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required" # Enforces IMDSv2 (token-based)
+    http_put_response_hop_limit = 1
+  }
+
+  # EBS encryption at rest — uses AWS-managed key (no additional cost)
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      encrypted   = true
+      volume_type = "gp3"
+      volume_size = 20
+    }
+  }
+
   # User data installs a basic web server for health check validation
   user_data = base64encode(<<-EOF
     #!/bin/bash

--- a/05-capstone/modules/cost/variables.tf
+++ b/05-capstone/modules/cost/variables.tf
@@ -17,7 +17,11 @@ variable "budget_limit" {
 }
 
 variable "alert_emails" {
-  description = "Email addresses for budget alert notifications"
+  description = "Email addresses for budget alert notifications — set in terraform.tfvars"
   type        = list(string)
-  default     = ["v.davidmedina@gmail.com"]
+
+  validation {
+    condition     = length(var.alert_emails) > 0
+    error_message = "At least one alert email address is required."
+  }
 }

--- a/05-capstone/providers.tf
+++ b/05-capstone/providers.tf
@@ -1,0 +1,45 @@
+# =============================================================================
+# 05-capstone/providers.tf
+# Provider and backend configuration for VDM Cloud Infrastructure Capstone
+# =============================================================================
+
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # ---------------------------------------------------------------------------
+  # Remote State — S3 Backend (see ADR-005: docs/adr/ADR-005-remote-state.md)
+  #
+  # The S3 bucket is created by backend-setup/. You must bootstrap it first:
+  #   cd backend-setup && terraform init && terraform apply && cd ..
+  #
+  # Then uncomment the block below and run:
+  #   terraform init -migrate-state
+  #
+  # Uses use_lockfile (Terraform 1.10+) instead of DynamoDB for state locking.
+  # See backend-setup/README.md for the full bootstrap walkthrough.
+  # ---------------------------------------------------------------------------
+  # backend "s3" {
+  #   bucket       = "vdm-terraform-state"
+  #   key          = "capstone/terraform.tfstate"
+  #   region       = "us-east-1"
+  #   use_lockfile = true
+  # }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project   = var.project_name
+      ManagedBy = "Terraform"
+    }
+  }
+}

--- a/05-capstone/terraform.tfvars.example
+++ b/05-capstone/terraform.tfvars.example
@@ -1,16 +1,32 @@
+# =============================================================================
 # terraform.tfvars.example
 # Copy to terraform.tfvars and customize for your environment
 #
 # Usage:
 #   cp terraform.tfvars.example terraform.tfvars
+#   # Edit terraform.tfvars with your values
 #   terraform init && terraform plan
+#
+# IMPORTANT: terraform.tfvars is gitignored — never commit real values
+# =============================================================================
 
+# --- Project ---
 project_name = "vdm-capstone"
 environment  = "dev"
 aws_region   = "us-east-1"
 
-# Network Configuration
+# --- Network ---
 vpc_cidr             = "10.0.0.0/16"
 public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
 private_subnet_cidrs = ["10.0.10.0/24", "10.0.20.0/24"]
 availability_zones   = ["us-east-1a", "us-east-1b"]
+
+# --- Notifications (REQUIRED — no default) ---
+alert_emails = ["your-email@example.com"]
+
+# --- Tags ---
+common_tags = {
+  Project   = "VDM-Cloud-Infrastructure"
+  ManagedBy = "Terraform"
+  Owner     = "David"
+}

--- a/05-capstone/variables.tf
+++ b/05-capstone/variables.tf
@@ -66,6 +66,16 @@ variable "aws_region" {
 }
 
 # -----------------------------------------------------------------------------
+# NOTIFICATIONS
+# Alert configuration for cost governance and operational notifications
+# -----------------------------------------------------------------------------
+
+variable "alert_emails" {
+  description = "Email addresses for budget and operational alert notifications — set in terraform.tfvars (not committed to version control)"
+  type        = list(string)
+}
+
+# -----------------------------------------------------------------------------
 # TAGGING
 # Standard tags applied to all resources for cost tracking and organization
 # -----------------------------------------------------------------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md — Project Guidance for Claude Code
+
+## Project Overview
+
+AWS Terraform Portfolio by Victor David Medina — production-grade AWS infrastructure
+built with Terraform, showcasing multi-AZ VPC architecture, Auto Scaling, GuardDuty,
+and comprehensive operational documentation. This is a portfolio project that
+demonstrates Day-2 operations thinking for cloud/SRE roles.
+
+## Repository Structure
+
+```
+aws-terraform-portfolio/
+├── 01-s3-bucket/          # Phase 1: S3 state backend basics
+├── 02-vpc/                # Phase 2: Basic VPC fundamentals
+├── 03-modules/            # Phase 3: Reusable module patterns
+├── 04-advanced-hcl/       # Phase 4: Workspaces, loops, validation
+├── 05-capstone/           # Phase 5: Production VPC stack (primary focus)
+│   ├── modules/           # Terraform modules (vpc, compute, security, monitoring, cost)
+│   ├── docs/              # ADRs, runbook, incident response, security decisions
+│   └── backend-setup/     # S3 remote state bootstrap
+├── backend-setup/         # Shared backend infrastructure
+├── docs/                  # Project-level documentation
+├── .bmad/                 # BMAD methodology (agents, skills, checklists)
+└── .github/workflows/     # CI/CD pipeline
+```
+
+## Key Commands
+
+```bash
+# Format check
+terraform fmt -check -recursive
+
+# Validate capstone (primary project)
+cd 05-capstone && terraform init -backend=false && terraform validate
+
+# Validate all phases
+for dir in 01-s3-bucket 02-vpc 03-modules 04-advanced-hcl 05-capstone; do
+  echo "=== $dir ===" && cd "$dir" && terraform init -backend=false && terraform validate && cd ..
+done
+
+# Security scan
+tfsec .
+
+# Plan (requires AWS credentials)
+cd 05-capstone && terraform plan
+```
+
+## Development Guidelines
+
+### Terraform Conventions
+- **Naming pattern**: `${project_name}-${var.environment}-${resource_type}`
+- **Tagging**: Always use `merge(var.common_tags, { ... })` for consistent tagging
+- **Variables**: Every variable must have a `description` and `type`
+- **Validation**: Use `validation` blocks on variables that accept constrained values
+- **Comments**: Document the "why" not the "what" — reference ADRs and security docs
+- **Modules**: One concern per module, consistent file structure (main.tf, variables.tf, outputs.tf)
+
+### Security Posture
+- No SSH — use SSM Session Manager (zero-trust access)
+- Security group chaining between tiers (web SG → db SG)
+- Private subnets for all application workloads
+- All security decisions documented in `05-capstone/docs/SECURITY-DECISIONS.md`
+- Never commit `.tfvars` files (they may contain sensitive values)
+
+### Documentation Standards
+- ADRs follow: Context → Decision → Alternatives → Consequences → Cost
+- Runbook entries follow: Symptoms → Severity → Diagnosis → Resolution → Verification
+- Every infrastructure decision should reference an ADR when applicable
+
+### CI/CD
+- `terraform fmt -check -recursive` on every push
+- `tfsec` security scanning on every push
+- `terraform validate` on capstone module
+- No AWS credentials in CI — validation only
+
+## BMAD Methodology
+
+This project uses the BMAD (BMad Agent-Driven) methodology for AI-assisted development.
+See `.bmad/` for agent definitions, skills, and quality checklists that guide
+infrastructure work on this portfolio.
+
+### Active Agents
+- **infra-architect**: Reviews architecture decisions and module design
+- **security-reviewer**: Validates security posture and compliance
+- **ops-engineer**: Focuses on operational readiness and runbook quality
+
+### Active Skills
+- **tf-module-review**: Terraform module quality and best practices review
+- **security-audit**: Security group and network policy audit
+- **cost-review**: FinOps and cost optimization review
+
+## Important Notes
+
+- Phases 01-04 are learning exercises; Phase 05 (capstone) is the production reference
+- The S3 backend block in `05-capstone/main.tf` is intentionally commented out for portability
+- Email addresses in `terraform.tfvars.example` are placeholders — real values go in `.tfvars` (gitignored)
+- This is a portfolio project — some production features (ALB, multi-NAT) are documented but not deployed to control costs


### PR DESCRIPTION
- Add CLAUDE.md project guidance with development conventions and key commands
- Add .bmad/ directory with agent definitions (infra-architect, security-reviewer,
  ops-engineer), reusable skills (tf-module-review, security-audit, cost-review),
  quality checklists (new-module, pr-review), and planned task (add-alb-module)
- Extract provider/backend config from main.tf to providers.tf with default_tags
- Add IMDSv2 enforcement (http_tokens = "required") to launch template
- Add EBS encryption at rest (gp3, encrypted) to launch template
- Remove hardcoded email from cost module defaults — now required via tfvars
- Add alert_emails variable to root module, wired through to cost module
- Expand terraform.tfvars.example with all variables including notifications and tags
- Restructure CI/CD: parallel format/security jobs, matrix validation across all phases
- Add explicit permissions block to GitHub Actions workflow
- Update .gitignore with Terraform overrides, .env, .claude/, and .swo patterns

https://claude.ai/code/session_01CrYkww6qcqvS7XSs4Cmb1K